### PR TITLE
fix: concurrent connections race conditions

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,6 +112,7 @@ func NewClientWithConfig(target, apiKey string, config *ClientConfig) *Client {
 		config: config,
 		target: target,
 		key:    apiKey,
+		logger: GetLogger(config.logLevel),
 	}
 }
 
@@ -130,8 +131,6 @@ func (c *Client) Connect(ctx context.Context) error {
 			}
 		}]
 	}`
-
-	c.logger = GetLogger(c.config.logLevel)
 
 	if c.config.enableCompression {
 		registerGzipCompression()

--- a/client.go
+++ b/client.go
@@ -225,9 +225,18 @@ func (c *Client) startHealthCheck() {
 // Close closes all the streams and then the underlying connection. IMPORTANT: you should call this
 // to ensure correct API accounting.
 func (c *Client) Close() error {
-	c.txStream.CloseSend()
-	c.txSeqStream.CloseSend()
-	c.submitBlockStream.CloseSend()
+	if c.txStream != nil {
+		c.txStream.CloseSend()
+	}
+	if c.txSeqStream != nil {
+		c.txSeqStream.CloseSend()
+	}
+	if c.submitBlockStream != nil {
+		c.submitBlockStream.CloseSend()
+	}
 
-	return c.conn.Close()
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentConnections tests for race conditions when creating multiple connections
+func TestConcurrentConnections(t *testing.T) {
+	// Skip unless explicitly enabled
+	if os.Getenv("RUN_RECONNECTION_TEST") != "true" {
+		t.Skip("Skipping reconnection test. Set RUN_RECONNECTION_TEST=true to run")
+	}
+
+	apiKey := os.Getenv("FIBER_API_KEY")
+	if apiKey == "" {
+		t.Skip("FIBER_API_KEY environment variable not set")
+	}
+
+	target := "beta.fiberapi.io:8080"
+
+	var wg sync.WaitGroup
+	numClients := 5
+
+	// Create multiple clients concurrently
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(clientID int) {
+			defer wg.Done()
+
+			client := NewClient(target, apiKey)
+			defer client.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if err := client.Connect(ctx); err != nil {
+				t.Errorf("Client %d failed to connect: %v", clientID, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
**Fixes**
- Multiple goroutines should not init logger concurrently
- Handle cleanup in `Close()` even if some components are `nil` (for example don't assume connection did happen)

**Testing** 
Set `RUN_RECONNECTION_TEST=true` and `FIBER_API_KEY`

Before changes
```
➜  fiber-go git:(main) ✗ go test -race ./...
# github.com/chainbound/fiber-go.test
ld: warning: '/private/var/folders/zt/f9pvbs_d3_39__s19xrbgdwr0000gn/T/go-link-2111969133/000014.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
2025-03-31T09:16:48.044+0200    INFO    Connected to beta.fiberapi.io:8080
2025-03-31T09:16:48.045+0200    DEBUG   Starting health check   {"interval": "10s"}
2025-03-31T09:16:48.045+0200    DEBUG   Subscribing to transactions
2025-03-31T09:16:48.656+0200    ERROR   Error receiving transactions    {"error": "rpc error: code = Canceled desc = grpc: the client connection is closing"}
2025-03-31T09:16:50.657+0200    DEBUG   Subscribing to transactions
2025-03-31T09:16:50.657+0200    ERROR   Error subscribing to transactions       {"error": "rpc error: code = Canceled desc = grpc: the client connection is closing"}
2025-03-31T09:16:52.658+0200    DEBUG   Subscribing to transactions
2025-03-31T09:16:52.659+0200    ERROR   Error subscribing to transactions       {"error": "rpc error: code = Canceled desc = grpc: the client connection is closing"}
2025-03-31T09:16:54.660+0200    DEBUG   Subscribing to transactions
2025-03-31T09:16:54.660+0200    ERROR   Error subscribing to transactions       {"error": "rpc error: code = Canceled desc = grpc: the client connection is closing"}
2025-03-31T09:16:56.661+0200    DEBUG   Subscribing to transactions
2025-03-31T09:16:56.661+0200    ERROR   Error subscribing to transactions       {"error": "rpc error: code = Canceled desc = grpc: the client connection is closing"}
2025-03-31T09:16:58.045+0200    WARN    Connection is not ready, reconnecting...
2025-03-31T09:16:58.150+0200    INFO    Connected to beta.fiberapi.io:8080
2025-03-31T09:16:58.150+0200    DEBUG   Starting health check   {"interval": "10s"}
==================
WARNING: DATA RACE
Read at 0x00c00019e108 by goroutine 117:
  go.uber.org/zap.(*SugaredLogger).log()
      /Users/awinninge/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:349 +0x60
  go.uber.org/zap.(*SugaredLogger).Debugw()
      /Users/awinninge/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:251 +0x270
  github.com/chainbound/fiber-go.(*Client).SubscribeNewTxs()
      /Users/awinninge/Developer/fiber-go/streams.go:206 +0x21c
  github.com/chainbound/fiber-go.(*Client).SubscribeNewTxs()
      /Users/awinninge/Developer/fiber-go/streams.go:218 +0x464
  github.com/chainbound/fiber-go.(*Client).SubscribeNewTxs()
      /Users/awinninge/Developer/fiber-go/streams.go:218 +0x464
  github.com/chainbound/fiber-go.testReconnection.func1()
      /Users/awinninge/Developer/fiber-go/reconnection_test.go:55 +0x44
```

After changes
```
➜  fiber-go git:(data-race) go test -race ./...
# github.com/chainbound/fiber-go.test
ld: warning: '/private/var/folders/zt/f9pvbs_d3_39__s19xrbgdwr0000gn/T/go-link-1005647892/000014.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ok      github.com/chainbound/fiber-go  (cached)
ok      github.com/chainbound/fiber-go/filter   (cached)
?       github.com/chainbound/fiber-go/protobuf/api     [no test files]
?       github.com/chainbound/fiber-go/protobuf/eth     [no test files]
?       github.com/chainbound/fiber-go/protobuf/types   [no test files]
```
