### PR TITLE
chore: log connection closing errors in health check

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,12 +204,9 @@ func (c *Client) startHealthCheck() {
 		if c.conn.GetState() != connectivity.Ready {
 			c.logger.Warn("Connection is not ready, reconnecting...")
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			// Reconnect
-			c.txStream.CloseSend()
-			c.txSeqStream.CloseSend()
-			c.submitBlockStream.CloseSend()
 
-			c.conn.Close()
+			// Close the connection and all streams
+			c.Close()
 
 			// Reconnect, this will start a new health check goroutine so we
 			// return from the current one.

--- a/client.go
+++ b/client.go
@@ -205,8 +205,10 @@ func (c *Client) startHealthCheck() {
 			c.logger.Warn("Connection is not ready, reconnecting...")
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 
-			// Close the connection and all streams
-			c.Close()
+			// Close the connection and all streams, logging any error during close
+			if err := c.Close(); err != nil {
+				c.logger.Warnf("Error closing client during health check reconnect: %v", err)
+			}
 
 			// Reconnect, this will start a new health check goroutine so we
 			// return from the current one.


### PR DESCRIPTION
Stacked on https://github.com/chainbound/fiber-go/pull/21

Before this we ignored potential errors when closing the connection. We also didn't check if streams and connections were non-nil, similar to https://github.com/chainbound/fiber-go/pull/21/commits/6c7de9fea9e74b80a3db757eede2d734d909777d