### PR TITLE
fix: cleanup connection when stream init fails

### DIFF
--- a/client.go
+++ b/client.go
@@ -172,16 +172,19 @@ func (c *Client) Connect(ctx context.Context) error {
 	ctx = metadata.AppendToOutgoingContext(ctx, "x-api-key", c.key, "x-client-version", Version)
 	c.txStream, err = c.client.SendTransactionV2(ctx)
 	if err != nil {
+		c.Close()
 		return err
 	}
 
 	c.txSeqStream, err = c.client.SendTransactionSequenceV2(ctx)
 	if err != nil {
+		c.Close()
 		return err
 	}
 
 	c.submitBlockStream, err = c.client.SubmitBlockStream(ctx)
 	if err != nil {
+		c.Close()
 		return err
 	}
 


### PR DESCRIPTION
If `client.Connect` is retried it might create multiple streams that are leaked.