### PR TITLE
chore: add linter to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0


### PR DESCRIPTION
Merge after lints are fixed

```
➜  fiber-go git:(lint) ✗ golangci-lint run
client.go:175:10: Error return value of `c.Close` is not checked (errcheck)
                c.Close()
                       ^
client.go:181:10: Error return value of `c.Close` is not checked (errcheck)
                c.Close()
                       ^
client.go:187:10: Error return value of `c.Close` is not checked (errcheck)
                c.Close()
                       ^
client_test.go:35:22: Error return value of `client.Close` is not checked (errcheck)
                        defer client.Close()
                                          ^
reconnection_test.go:38:19: Error return value of `fiber.Close` is not checked (errcheck)
        defer fiber.Close()
                         ^
reconnection_test.go:91:18: Error return value of `fiber.conn.Close` is not checked (errcheck)
        fiber.conn.Close()
                        ^
compression.go:51:4: QF1008: could remove embedded field "Writer" from selector (staticcheck)
        z.Writer.Reset(w)
          ^
7 issues:
* errcheck: 6
* staticcheck: 1
```