### PR TITLE
chore: log when err cleaning up stream init err

### DIFF
--- a/client.go
+++ b/client.go
@@ -172,19 +172,25 @@ func (c *Client) Connect(ctx context.Context) error {
 	streamCtx := metadata.AppendToOutgoingContext(context.Background(), "x-api-key", c.key, "x-client-version", Version)
 	c.txStream, err = c.client.SendTransactionV2(streamCtx)
 	if err != nil {
-		c.Close()
+		if closeErr := c.Close(); closeErr != nil {
+			c.logger.Warnf("Error closing client during initial txStream setup: %v", closeErr)
+		}
 		return err
 	}
 
 	c.txSeqStream, err = c.client.SendTransactionSequenceV2(streamCtx)
 	if err != nil {
-		c.Close()
+		if closeErr := c.Close(); closeErr != nil {
+			c.logger.Warnf("Error closing client during initial txSeqStream setup: %v", closeErr)
+		}
 		return err
 	}
 
 	c.submitBlockStream, err = c.client.SubmitBlockStream(streamCtx)
 	if err != nil {
-		c.Close()
+		if closeErr := c.Close(); closeErr != nil {
+			c.logger.Warnf("Error closing client during initial submitBlockStream setup: %v", closeErr)
+		}
 		return err
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -32,7 +32,11 @@ func TestConcurrentConnections(t *testing.T) {
 			defer wg.Done()
 
 			client := NewClient(target, apiKey)
-			defer client.Close()
+			defer func() {
+				if err := client.Close(); err != nil {
+					t.Logf("Client %d failed to close cleanly: %v", clientID, err)
+				}
+			}()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()

--- a/reconnection_test.go
+++ b/reconnection_test.go
@@ -35,7 +35,11 @@ func testReconnection(t *testing.T, target, apiKey string) {
 
 	// Create client
 	fiber := NewClientWithConfig(target, apiKey, config)
-	defer fiber.Close()
+	defer func() {
+		if err := fiber.Close(); err != nil {
+			t.Logf("Error closing fiber client: %v", err)
+		}
+	}()
 
 	// Connect to the API
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -88,7 +92,9 @@ initialWait:
 	// Simulate a network interruption by forcibly closing the connection
 	t.Log("Simulating network interruption...")
 	disconnectTime := time.Now()
-	fiber.conn.Close()
+	if err := fiber.conn.Close(); err != nil {
+		t.Logf("Error forcibly closing connection: %v", err)
+	}
 
 	// Now wait for transactions to appear after reconnection
 	t.Log("Waiting for reconnection...")


### PR DESCRIPTION
If we got a failure trying to init a stream and and error closing the connection, the connection error would not be logged