### PR TITLE
chore: simplify reset call

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -48,7 +48,7 @@ func SetLevel(level int) error {
 
 func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
 	z := c.poolCompressor.Get().(*writer)
-	z.Writer.Reset(w)
+	z.Reset(w)
 	return z, nil
 }
 


### PR DESCRIPTION
```
compression.go:51:4: QF1008: could remove embedded field "Writer" from selector (staticcheck)
        z.Writer.Reset(w)
          ^
```

When a type is embedded like this, its method is promoted to the containing type.

```go
type writer struct {
	*gzip.Writer
	pool *sync.Pool
}
```