### PR TITLE
feat: enable keepalives by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ client := fiber.NewClientWithConfig(endpoint, apiKey, config)
 - `SetReadBufferSize(size int)`: Sets the gRPC read buffer size
 - `SetConnWindowSize(size int32)`: Sets the gRPC connection window size
 - `SetWindowSize(size int32)`: Sets the gRPC window size
-- `SetIdleTimeout(timeout time.Duration)`: Sets a timeout after which idle connections will be restarted automatically. Set to 0 to disable (default).
+- `SetIdleTimeout(timeout time.Duration)`: Sets a timeout after which idle connections will be restarted automatically. Set to 0 to disable. 10s is default value.
 - `SetHealthCheckInterval(interval time.Duration)`: Sets the interval for health checks. Set to 0 to disable (default).
 - `SetLogLevel(level string)`: Sets the log level. Default is `panic` (which never logs).
 

--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ func NewConfig() *ClientConfig {
 		readBufferSize:    1024 * 8,
 		connWindowSize:    1024 * 512,
 		windowSize:        1024 * 256,
-		idleTimeout:       0,
+		idleTimeout:       10 * time.Second,
 		hcInterval:        10 * time.Second,
 		logLevel:          "fatal",
 	}


### PR DESCRIPTION
Graduates keepalives to being enabled by default.
Depends on Fiber server support for keepalives.